### PR TITLE
Check for item after get attempt instead of before

### DIFF
--- a/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
@@ -280,11 +280,11 @@ class DynamoDbStorage implements Storage
           self::TABLE_KEY           => $this->prepareKey($storageName, $key),
         ]);
 
+        $item = $item->get(self::TABLE_ITEM_KEY);
+
         if (! $item) {
             throw NotFoundException::notFoundByKey($key);
         }
-
-        $item = $item->get(self::TABLE_ITEM_KEY);
 
         return $this->marshaler->unmarshalItem($item);
     }

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
@@ -310,11 +310,13 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
     public function testTryingToFindAnItemThatDoesNotExist()
     {
         $client = $this->getDynamoDbMock(['getItem']);
+        $result = $this->getDynamoDbResultMock(['get']);
+        $result->expects($this->once())->method('get')->with('Item')->willReturn(null);
         $client->expects($this->once())->method('getItem')->with($this->equalTo([
             'TableName'      => 'MyTable',
             'ConsistentRead' => true,
             'Key'            => ['Id' => ['N' => '1000']],
-        ]))->willReturn(null);
+        ]))->willReturn($result);
 
         $storage = new DynamoDbStorage($client);
         $this->setExpectedException(


### PR DESCRIPTION
The code below returns an object of Aws\Result even when the table key does not exist in DynamoDB:
```
$item = $this->client->getItem([
    self::TABLE_NAME_KEY      => $storageName,
    self::CONSISTENT_READ_KEY => true,
    self::TABLE_KEY           => $this->prepareKey($storageName, $key),
]);
```
Causing this check to pass:
```
if (! $item) {
   throw NotFoundException::notFoundByKey($key);
}
```
Since the key does not exist a null value is set here:
`$item = $item->get(self::TABLE_ITEM_KEY);`
Then that null $item is passed to:
`$this->marshaler->unmarshalItem($item);`
Which causes a fatal error.

This fix checks $item after attempting to get it instead of before.